### PR TITLE
Fix EnterWorktree CWD sharing: replace using-git-worktrees with direct git worktree add

### DIFF
--- a/docs/plans/2026-03-13-enterworktree-cwd.md
+++ b/docs/plans/2026-03-13-enterworktree-cwd.md
@@ -1,150 +1,36 @@
-# Plan: Document EnterWorktree CWD sharing and add workaround (Issue #33)
+# Plan: Fix EnterWorktree CWD sharing (Issue #33)
 
 ## Problem
 
-When two lightbulb agents are launched in parallel from the same session, `EnterWorktree` changes the working directory for the entire session -- not just the agent that invoked it. This causes the second agent to find itself inside the first agent's worktree, unable to create its own.
+`EnterWorktree` changes the session CWD for the **entire session**, not just the agent that invoked it. This was confirmed experimentally:
 
-### Root Cause Analysis
+- Two parallel agents launched from main repo root
+- Agent A called `EnterWorktree` (no exit)
+- Parent session CWD changed to agent A's worktree
+- Agent B was unaffected (launched before the side effect)
 
-There are **two separate worktree mechanisms** in the lightbulb workflow, and their interaction creates the problem:
+This breaks parallel lightbulb execution — the second agent lands in the first's worktree.
 
-1. **`EnterWorktree`** (Claude Code platform tool) -- creates worktrees in `.claude/worktrees/` and "switches the session's working directory to the new worktree." This is a session-level side effect. Its description also states it requires "must not already be in a worktree."
+## Root Cause
 
-2. **`superpowers:using-git-worktrees`** (skill) -- creates worktrees in `.worktrees/` (or `worktrees/`) and uses `cd "$path"` to change into them. This is a shell-level side effect that does not persist across Bash tool calls.
-
-The lightbulb skill's Step 2 invokes `superpowers:using-git-worktrees`, which uses `cd` and `git worktree add`. However, when the lightbulb is launched via the Agent tool with `isolation: "worktree"`, the platform itself calls `EnterWorktree` to set up the agent's execution context *before* the agent starts. This `EnterWorktree` call modifies shared session state.
-
-### Evidence from the repository
-
-The worktree list shows the nesting pattern:
-
-```
-/home/maurezen/git_tree/around                                                  (main repo)
-/home/maurezen/git_tree/around/.claude/worktrees/issue-30-simplify-review-diff  (EnterWorktree)
-/home/maurezen/git_tree/around/.claude/worktrees/issue-30-simplify-review-diff/.claude/worktrees/agent-a8fdc750  (nested EnterWorktree)
-/home/maurezen/git_tree/around/.worktrees/issue-33-enterworktree-cwd            (using-git-worktrees)
-```
-
-The `.claude/worktrees/` entries are created by `EnterWorktree`. The `.worktrees/` entries are created by `superpowers:using-git-worktrees`. The nested worktree (`agent-a8fdc750` inside `issue-30`) confirms that `EnterWorktree` was called from within an existing worktree -- contradicting its own "must not already be in a worktree" requirement.
-
-### Why parallel lightbulb agents fail
-
-1. **Agent #30** launches, `EnterWorktree` changes the session CWD to `.claude/worktrees/issue-30-...`
-2. **Agent #31** launches (same session), finds itself already in `.claude/worktrees/issue-30-...`
-3. Agent #31 tries to call `EnterWorktree` but fails because it's "already in a worktree"
-4. Agent #31 falls back to the `superpowers:using-git-worktrees` skill, which tries to create `.worktrees/` relative to the current directory -- but the current directory is agent #30's worktree
-5. The orchestrator's `pwd` also shows agent #30's worktree because `EnterWorktree` changed the session-level CWD
-
-### Key insight
-
-`EnterWorktree` is a **Claude Code platform behavior**, not something the lightbulb skill controls. The `superpowers:using-git-worktrees` skill does not call `EnterWorktree` -- it uses `git worktree add` + `cd`. But when agents are dispatched with `isolation: "worktree"` or when the skill is invoked in certain contexts, the platform may use `EnterWorktree` under the hood.
+`EnterWorktree` is a session-level operation. `ExitWorktree` restores the CWD, but lightbulb agents don't call it (they leave worktrees around for PRs). The `isolation: "worktree"` parameter also doesn't protect — agents inside isolated worktrees that call `EnterWorktree` still corrupt the parent session CWD.
 
 ## Solution
 
-Since `EnterWorktree` is a platform tool whose session-level CWD side effect cannot be changed by this project, the solution has two parts:
+Replace `superpowers:using-git-worktrees` in Step 2 with direct `git worktree add` + `git -C`. This avoids all CWD-changing mechanisms:
 
-1. **Document the limitation** in the lightbulb SKILL.md so that users and the LLM understand why parallel agents from the same session fail.
-2. **Add defensive guidance** to the lightbulb skill so that:
-   - The orchestrator avoids dispatching parallel lightbulb agents from the same session
-   - If parallel agents are needed, the guidance recommends using separate Claude Code sessions
-   - The existing anti-piggybacking check (branch name verification in Step 2) catches cases where an agent ends up in the wrong worktree
-
-### What NOT to change
-
-- The `superpowers:using-git-worktrees` skill is an external dependency and cannot be modified.
-- The `EnterWorktree` tool is a Claude Code platform tool and cannot be modified.
-- The existing branch name verification in Step 2 already catches the piggybacking case -- no changes needed there.
-
-## Tasks
-
-### Task 1: Add "Known Limitation" section to SKILL.md
-
-**Files:**
-- Modify: `skills/lightbulb/SKILL.md`
-
-Add a new section after `## Error Handling` and before `## Red Flags` that documents the parallel agent limitation:
-
-```markdown
-## Known Limitations
-
-### Parallel lightbulb agents share session CWD
-
-The `EnterWorktree` tool (a Claude Code platform tool) changes the working directory for the **entire session**, not just the agent that invoked it. When two lightbulb agents are launched in parallel from the same session:
-
-1. The first agent's worktree setup changes the session CWD
-2. The second agent starts inside the first agent's worktree
-3. The second agent cannot create its own worktree (already in a worktree)
-
-**Workaround:** Launch parallel lightbulb agents from separate Claude Code sessions. Each session maintains its own CWD, so `EnterWorktree` in one session does not affect the other.
-
-**Detection:** The branch name verification in Step 2 catches this case -- if an agent finds itself in a worktree whose branch doesn't match its issue number, it stops and reports the error rather than piggybacking on the wrong worktree.
+```bash
+ls -d .worktrees 2>/dev/null || mkdir .worktrees
+git check-ignore -q .worktrees || echo ".worktrees" >> .gitignore
+git worktree add .worktrees/issue-<N>-<slug> -b feature/issue-<N>-<slug>
+WORKTREE_PATH="<repo-root>/.worktrees/issue-<N>-<slug>"
 ```
 
-### Task 2: Add "Never" red flag for parallel lightbulb agents
+Verified: two parallel agents using this approach both created worktrees successfully without CWD corruption.
 
-**Files:**
-- Modify: `skills/lightbulb/SKILL.md`
+## Changes
 
-In the `**Never:**` list in the Red Flags section, add a new bullet after the existing item about chaining Bash commands:
-
-```markdown
-- Dispatch multiple lightbulb agents in parallel from the same session -- `EnterWorktree` shares CWD across the session, so the second agent will land in the first agent's worktree (see **Known Limitations**)
-```
-
-### Task 3: Update the orchestrator dispatch guidance
-
-**Files:**
-- Modify: `skills/lightbulb/SKILL.md`
-
-The existing "Red Flags > Never" list already contains "Dispatch subagents in parallel -- phases are sequential." This covers the *within-a-single-lightbulb* case. But a user might invoke `/lightbulb 30` and `/lightbulb 31` from the same session, expecting them to run in parallel.
-
-Add a note to the top of the skill (after the `**Announce at start:**` block and before `## Input`) to make this explicit:
-
-```markdown
-**Parallel execution:** This skill does not support running multiple lightbulb instances in parallel from the same Claude Code session. Each lightbulb invocation modifies the session's working directory via worktree setup. To develop multiple issues in parallel, use separate Claude Code sessions (one per issue).
-```
-
-### Task 4: Verify the branch name check covers the failure mode
-
-**Files:**
-- Read (no modification): `skills/lightbulb/SKILL.md`
-
-Verify that Step 2's existing branch name verification would catch the case described in the issue:
-
-1. Agent #31 starts in agent #30's worktree (`.claude/worktrees/issue-30-...`)
-2. The branch in that worktree is `feature/issue-30-...`
-3. Agent #31's target issue is #31
-4. The check: `echo "$CURRENT_BRANCH" | grep -q "issue-31"` -- fails because the branch contains `issue-30`, not `issue-31`
-5. Agent #31 stops and reports error
-
-This should already work. No changes needed -- just verify and document.
-
-## Out of Scope
-
-- Modifying the `EnterWorktree` tool (platform tool, not ours)
-- Modifying `superpowers:using-git-worktrees` (external dependency)
-- Implementing a workaround that avoids `EnterWorktree` entirely (would require forking the superpowers skill)
-- Adding `isolation: "worktree"` guidance to the Agent tool dispatch (this is a Claude Code platform parameter, not something the skill controls)
-
-## Verification
-
-After all tasks:
-
-1. **Read the complete SKILL.md** and verify:
-   - The "Known Limitations" section exists between "Error Handling" and "Red Flags"
-   - The "Parallel execution" note appears near the top of the skill
-   - The new "Never" red flag about parallel lightbulb agents is present
-   - No other sections were accidentally modified
-
-2. **Trace the failure scenario through the updated logic:**
-   - User runs `/lightbulb 30` and `/lightbulb 31` from the same session
-   - The "Parallel execution" note at the top warns against this
-   - If the user proceeds anyway:
-     - Agent #30 creates worktree, session CWD changes
-     - Agent #31 starts in agent #30's worktree
-     - Step 2 branch verification catches the mismatch (`issue-30` != `issue-31`)
-     - Agent #31 stops and reports the error
-     - The "Known Limitations" section explains why this happened
-   - Result: no piggybacking, clear error message, documented workaround
-
-3. **Verify the "Never" red flag list** is consistent -- the new parallel-agents entry does not conflict with existing entries.
+1. **Step 2** — replaced `superpowers:using-git-worktrees` with direct `git worktree add` instructions
+2. **Red Flags** — added "Never use EnterWorktree or superpowers:using-git-worktrees"
+3. **Integration** — moved `using-git-worktrees` from "called" to "NOT called" with explanation
+4. **Flow diagram** — removed "REQUIRED SUB-SKILL" reference

--- a/docs/plans/2026-03-13-enterworktree-cwd.md
+++ b/docs/plans/2026-03-13-enterworktree-cwd.md
@@ -1,0 +1,150 @@
+# Plan: Document EnterWorktree CWD sharing and add workaround (Issue #33)
+
+## Problem
+
+When two lightbulb agents are launched in parallel from the same session, `EnterWorktree` changes the working directory for the entire session -- not just the agent that invoked it. This causes the second agent to find itself inside the first agent's worktree, unable to create its own.
+
+### Root Cause Analysis
+
+There are **two separate worktree mechanisms** in the lightbulb workflow, and their interaction creates the problem:
+
+1. **`EnterWorktree`** (Claude Code platform tool) -- creates worktrees in `.claude/worktrees/` and "switches the session's working directory to the new worktree." This is a session-level side effect. Its description also states it requires "must not already be in a worktree."
+
+2. **`superpowers:using-git-worktrees`** (skill) -- creates worktrees in `.worktrees/` (or `worktrees/`) and uses `cd "$path"` to change into them. This is a shell-level side effect that does not persist across Bash tool calls.
+
+The lightbulb skill's Step 2 invokes `superpowers:using-git-worktrees`, which uses `cd` and `git worktree add`. However, when the lightbulb is launched via the Agent tool with `isolation: "worktree"`, the platform itself calls `EnterWorktree` to set up the agent's execution context *before* the agent starts. This `EnterWorktree` call modifies shared session state.
+
+### Evidence from the repository
+
+The worktree list shows the nesting pattern:
+
+```
+/home/maurezen/git_tree/around                                                  (main repo)
+/home/maurezen/git_tree/around/.claude/worktrees/issue-30-simplify-review-diff  (EnterWorktree)
+/home/maurezen/git_tree/around/.claude/worktrees/issue-30-simplify-review-diff/.claude/worktrees/agent-a8fdc750  (nested EnterWorktree)
+/home/maurezen/git_tree/around/.worktrees/issue-33-enterworktree-cwd            (using-git-worktrees)
+```
+
+The `.claude/worktrees/` entries are created by `EnterWorktree`. The `.worktrees/` entries are created by `superpowers:using-git-worktrees`. The nested worktree (`agent-a8fdc750` inside `issue-30`) confirms that `EnterWorktree` was called from within an existing worktree -- contradicting its own "must not already be in a worktree" requirement.
+
+### Why parallel lightbulb agents fail
+
+1. **Agent #30** launches, `EnterWorktree` changes the session CWD to `.claude/worktrees/issue-30-...`
+2. **Agent #31** launches (same session), finds itself already in `.claude/worktrees/issue-30-...`
+3. Agent #31 tries to call `EnterWorktree` but fails because it's "already in a worktree"
+4. Agent #31 falls back to the `superpowers:using-git-worktrees` skill, which tries to create `.worktrees/` relative to the current directory -- but the current directory is agent #30's worktree
+5. The orchestrator's `pwd` also shows agent #30's worktree because `EnterWorktree` changed the session-level CWD
+
+### Key insight
+
+`EnterWorktree` is a **Claude Code platform behavior**, not something the lightbulb skill controls. The `superpowers:using-git-worktrees` skill does not call `EnterWorktree` -- it uses `git worktree add` + `cd`. But when agents are dispatched with `isolation: "worktree"` or when the skill is invoked in certain contexts, the platform may use `EnterWorktree` under the hood.
+
+## Solution
+
+Since `EnterWorktree` is a platform tool whose session-level CWD side effect cannot be changed by this project, the solution has two parts:
+
+1. **Document the limitation** in the lightbulb SKILL.md so that users and the LLM understand why parallel agents from the same session fail.
+2. **Add defensive guidance** to the lightbulb skill so that:
+   - The orchestrator avoids dispatching parallel lightbulb agents from the same session
+   - If parallel agents are needed, the guidance recommends using separate Claude Code sessions
+   - The existing anti-piggybacking check (branch name verification in Step 2) catches cases where an agent ends up in the wrong worktree
+
+### What NOT to change
+
+- The `superpowers:using-git-worktrees` skill is an external dependency and cannot be modified.
+- The `EnterWorktree` tool is a Claude Code platform tool and cannot be modified.
+- The existing branch name verification in Step 2 already catches the piggybacking case -- no changes needed there.
+
+## Tasks
+
+### Task 1: Add "Known Limitation" section to SKILL.md
+
+**Files:**
+- Modify: `skills/lightbulb/SKILL.md`
+
+Add a new section after `## Error Handling` and before `## Red Flags` that documents the parallel agent limitation:
+
+```markdown
+## Known Limitations
+
+### Parallel lightbulb agents share session CWD
+
+The `EnterWorktree` tool (a Claude Code platform tool) changes the working directory for the **entire session**, not just the agent that invoked it. When two lightbulb agents are launched in parallel from the same session:
+
+1. The first agent's worktree setup changes the session CWD
+2. The second agent starts inside the first agent's worktree
+3. The second agent cannot create its own worktree (already in a worktree)
+
+**Workaround:** Launch parallel lightbulb agents from separate Claude Code sessions. Each session maintains its own CWD, so `EnterWorktree` in one session does not affect the other.
+
+**Detection:** The branch name verification in Step 2 catches this case -- if an agent finds itself in a worktree whose branch doesn't match its issue number, it stops and reports the error rather than piggybacking on the wrong worktree.
+```
+
+### Task 2: Add "Never" red flag for parallel lightbulb agents
+
+**Files:**
+- Modify: `skills/lightbulb/SKILL.md`
+
+In the `**Never:**` list in the Red Flags section, add a new bullet after the existing item about chaining Bash commands:
+
+```markdown
+- Dispatch multiple lightbulb agents in parallel from the same session -- `EnterWorktree` shares CWD across the session, so the second agent will land in the first agent's worktree (see **Known Limitations**)
+```
+
+### Task 3: Update the orchestrator dispatch guidance
+
+**Files:**
+- Modify: `skills/lightbulb/SKILL.md`
+
+The existing "Red Flags > Never" list already contains "Dispatch subagents in parallel -- phases are sequential." This covers the *within-a-single-lightbulb* case. But a user might invoke `/lightbulb 30` and `/lightbulb 31` from the same session, expecting them to run in parallel.
+
+Add a note to the top of the skill (after the `**Announce at start:**` block and before `## Input`) to make this explicit:
+
+```markdown
+**Parallel execution:** This skill does not support running multiple lightbulb instances in parallel from the same Claude Code session. Each lightbulb invocation modifies the session's working directory via worktree setup. To develop multiple issues in parallel, use separate Claude Code sessions (one per issue).
+```
+
+### Task 4: Verify the branch name check covers the failure mode
+
+**Files:**
+- Read (no modification): `skills/lightbulb/SKILL.md`
+
+Verify that Step 2's existing branch name verification would catch the case described in the issue:
+
+1. Agent #31 starts in agent #30's worktree (`.claude/worktrees/issue-30-...`)
+2. The branch in that worktree is `feature/issue-30-...`
+3. Agent #31's target issue is #31
+4. The check: `echo "$CURRENT_BRANCH" | grep -q "issue-31"` -- fails because the branch contains `issue-30`, not `issue-31`
+5. Agent #31 stops and reports error
+
+This should already work. No changes needed -- just verify and document.
+
+## Out of Scope
+
+- Modifying the `EnterWorktree` tool (platform tool, not ours)
+- Modifying `superpowers:using-git-worktrees` (external dependency)
+- Implementing a workaround that avoids `EnterWorktree` entirely (would require forking the superpowers skill)
+- Adding `isolation: "worktree"` guidance to the Agent tool dispatch (this is a Claude Code platform parameter, not something the skill controls)
+
+## Verification
+
+After all tasks:
+
+1. **Read the complete SKILL.md** and verify:
+   - The "Known Limitations" section exists between "Error Handling" and "Red Flags"
+   - The "Parallel execution" note appears near the top of the skill
+   - The new "Never" red flag about parallel lightbulb agents is present
+   - No other sections were accidentally modified
+
+2. **Trace the failure scenario through the updated logic:**
+   - User runs `/lightbulb 30` and `/lightbulb 31` from the same session
+   - The "Parallel execution" note at the top warns against this
+   - If the user proceeds anyway:
+     - Agent #30 creates worktree, session CWD changes
+     - Agent #31 starts in agent #30's worktree
+     - Step 2 branch verification catches the mismatch (`issue-30` != `issue-31`)
+     - Agent #31 stops and reports the error
+     - The "Known Limitations" section explains why this happened
+   - Result: no piggybacking, clear error message, documented workaround
+
+3. **Verify the "Never" red flag list** is consistent -- the new parallel-agents entry does not conflict with existing entries.

--- a/skills/lightbulb/SKILL.md
+++ b/skills/lightbulb/SKILL.md
@@ -47,7 +47,7 @@ IF TOPIC MODE:
 
 BOTH MODES (from here on, issue_number is always set):
   1. Parse/fetch issue from GitHub
-  2. Set up worktree — REQUIRED SUB-SKILL: superpowers:using-git-worktrees
+  2. Set up worktree (direct git worktree add — no EnterWorktree, no cd)
   3. PLAN — dispatch planning subagent
   4. IMPLEMENT — dispatch implementation subagent
   5. Create draft PR linked to the issue
@@ -160,22 +160,35 @@ If the issue doesn't exist or is closed, tell the user and stop.
 
 ## Step 2: Set Up Worktree
 
-**REQUIRED SUB-SKILL:** Use `superpowers:using-git-worktrees` to create an isolated workspace.
+Create an isolated worktree directly using `git worktree add`. Do **not** use `EnterWorktree` or `superpowers:using-git-worktrees` — both change the session's working directory, which breaks parallel agent execution.
 
 The worktree branch name should be derived from the issue: `feature/issue-<number>-<slug>` where `<slug>` is a short kebab-case summary of the issue title.
 
-**After worktree setup, store the worktree path and verify ownership:**
+**Create the worktree** (each command as a separate Bash tool call):
 
-The `superpowers:using-git-worktrees` skill outputs the worktree path. Store it in a variable for all subsequent git operations:
+```bash
+# Ensure worktree directory exists and is gitignored
+ls -d .worktrees 2>/dev/null || mkdir .worktrees
+```
+```bash
+git check-ignore -q .worktrees || echo ".worktrees" >> .gitignore
+```
+```bash
+# Create the worktree with a new branch
+git worktree add .worktrees/issue-<number>-<slug> -b feature/issue-<number>-<slug>
+```
+
+**Store the worktree path** for all subsequent git operations:
 
 ```
-WORKTREE_PATH="<path returned by using-git-worktrees>"
+WORKTREE_PATH="<repo-root>/.worktrees/issue-<number>-<slug>"
 ```
 
 Use `git -C "$WORKTREE_PATH"` for all subsequent git commands (see **Git Commands (Worktree Convention)** section above).
 
+**Verify ownership:**
+
 ```bash
-# Verify the current branch contains this issue's number
 CURRENT_BRANCH=$(git -C "$WORKTREE_PATH" rev-parse --abbrev-ref HEAD)
 echo "$CURRENT_BRANCH" | grep -q "issue-<number>" || echo "BRANCH_MISMATCH"
 ```
@@ -439,6 +452,7 @@ If a subagent needs user input but doesn't use the `USER_INPUT_NEEDED:` protocol
 - Work in a worktree or commit to a branch that belongs to a different issue -- if your worktree is inaccessible or the branch name doesn't match your issue number, report the error and stop
 - Chain Bash commands with `&&` — run each command as a separate Bash tool call (see **Orchestrator Bash Commands** section)
 - Use `cd` to change into a worktree directory -- not in a `cd && git` chain, not as a standalone `cd` before git commands, not ever. Use `git -C "$WORKTREE_PATH"` instead (see **Git Commands (Worktree Convention)** section)
+- Use `EnterWorktree` or `superpowers:using-git-worktrees` -- both change the session CWD, which breaks parallel agent execution. Use `git worktree add` directly (see **Step 2**)
 
 **Always:**
 - Relay brainstorming questions to the user — don't answer them yourself
@@ -456,11 +470,11 @@ If a subagent needs user input but doesn't use the `USER_INPUT_NEEDED:` protocol
 ## Integration
 
 **Skills called (via subagents):**
-- `superpowers:using-git-worktrees` — worktree setup (orchestrator invokes directly)
 - `superpowers:brainstorming` — topic-to-issue brainstorm (topic mode, brainstorming subagent) AND design exploration (planning subagent)
 - `superpowers:writing-plans` — plan creation (planning subagent)
 - `superpowers:subagent-driven-development` — implementation (implementer subagent)
 
 **Skills NOT called:**
+- `superpowers:using-git-worktrees` — orchestrator creates worktrees directly via `git worktree add` to avoid session CWD side effects
 - `superpowers:finishing-a-development-branch` — orchestrator handles PR lifecycle directly
 - `superpowers:executing-plans` — SDD used instead


### PR DESCRIPTION
## Summary

- Replaced `superpowers:using-git-worktrees` in Step 2 with direct `git worktree add` + `git -C` to avoid session CWD corruption
- Added "Never use EnterWorktree or superpowers:using-git-worktrees" to Red Flags
- Moved `using-git-worktrees` from "Skills called" to "Skills NOT called" in Integration section

## Investigation

Experimentally confirmed that `EnterWorktree` changes the **session-level** CWD (not just the calling agent's). Parallel agents using `git worktree add` + `git -C` instead do not corrupt the parent session CWD.

Full experiment results: https://github.com/fumb13s/around/issues/33#issuecomment-4057141668 and https://github.com/fumb13s/around/issues/33#issuecomment-4057340267

Closes #33

---

Autonomously developed with the lightbulb skill.

— Claude